### PR TITLE
Add repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
     "account",
     "model"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/twilson63/couchdb-user-account.git"
+  },
   "author": "Tom",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Having the repo in the package.json makes it easier to navigate to the repo from npmjs.com.
